### PR TITLE
Count subscription check failures, rather than posting errors

### DIFF
--- a/gif_pipeline/database_schema.sql
+++ b/gif_pipeline/database_schema.sql
@@ -97,7 +97,8 @@ create table if not exists subscriptions
             on update restrict on delete cascade,
     last_check_time text,
     check_rate text,
-    enabled boolean
+    enabled boolean,
+    failures integer
 );
 
 create unique index if not exists subscription_id_uindex

--- a/gif_pipeline/database_schema.sql
+++ b/gif_pipeline/database_schema.sql
@@ -98,7 +98,7 @@ create table if not exists subscriptions
     last_check_time text,
     check_rate text,
     enabled boolean,
-    failures integer
+    failures integer default 0
 );
 
 create unique index if not exists subscription_id_uindex

--- a/gif_pipeline/helpers/subscription_helper.py
+++ b/gif_pipeline/helpers/subscription_helper.py
@@ -158,7 +158,7 @@ class SubscriptionHelper(Helper):
                             text=f"Failed to post item {item.source_link} from {feed_url} feed due to: {e}",
                             buttons=[[Button.inline("Delete error", "delete_me")]]
                         )
-            subscription.failures = 0
+                subscription.failures = 0
             subscription.last_check_time = datetime.now()
             if subscription.feed_url in [sub.feed_url for sub in self.subscriptions[:]]:
                 self.save_subscription(subscription)

--- a/gif_pipeline/helpers/subscription_helper.py
+++ b/gif_pipeline/helpers/subscription_helper.py
@@ -160,8 +160,7 @@ class SubscriptionHelper(Helper):
                         )
                 subscription.failures = 0
             subscription.last_check_time = datetime.now()
-            if subscription.feed_url in [sub.feed_url for sub in self.subscriptions[:]]:
-                self.save_subscription(subscription)
+            self.save_subscription(subscription)
 
     async def post_item(self, item: "Item", subscription: "Subscription") -> None:
         # Get chat
@@ -281,6 +280,9 @@ class SubscriptionHelper(Helper):
 
     def save_subscription(self, subscription: Subscription) -> None:
         new_sub = subscription.subscription_id is None
+        current_sub_ids = [sub.subscription_id for sub in self.subscriptions]
+        if not new_sub and subscription.subscription_id not in current_sub_ids:
+            return
         saved_data = self.database.save_subscription(subscription.to_data(), subscription.seen_item_ids)
         if new_sub:
             subscription.subscription_id = saved_data.subscription_id

--- a/gif_pipeline/helpers/subscription_helper.py
+++ b/gif_pipeline/helpers/subscription_helper.py
@@ -225,11 +225,15 @@ class SubscriptionHelper(Helper):
             return [await self.send_text_reply(chat, message, "Please specify a feed link to subscribe to.")]
         if split_text[1] in ["list"]:
             msg = "List of subscriptions currently posting to this chat are:\n"
-            msg += "\n".join(
-                f"- {html.escape(sub.feed_url)}"
-                for sub in self.subscriptions
-                if sub.chat_id == chat.chat_data.chat_id
-            )
+            lines = []
+            for sub in self.subscriptions:
+                if sub.chat_id != chat.chat_data.chat_id:
+                    continue
+                line = f"- {html.escape(sub.feed_url)}"
+                if sub.failures > 0:
+                    line += f" (Failed last {sub.failures} checks)"
+                lines.append(line)
+            msg += "\n".join(lines)
             return [await self.send_text_reply(chat, message, msg)]
         if split_text[1] in ["remove", "delete"]:
             feed_link = split_text[2]

--- a/gif_pipeline/helpers/subscription_helper.py
+++ b/gif_pipeline/helpers/subscription_helper.py
@@ -158,6 +158,7 @@ class SubscriptionHelper(Helper):
                             text=f"Failed to post item {item.source_link} from {feed_url} feed due to: {e}",
                             buttons=[[Button.inline("Delete error", "delete_me")]]
                         )
+            subscription.failures = 0
             subscription.last_check_time = datetime.now()
             if subscription.feed_url in [sub.feed_url for sub in self.subscriptions[:]]:
                 self.save_subscription(subscription)

--- a/gif_pipeline/helpers/subscription_helper.py
+++ b/gif_pipeline/helpers/subscription_helper.py
@@ -137,12 +137,10 @@ class SubscriptionHelper(Helper):
             try:
                 new_items = await subscription.check_for_new_items()
             except Exception as e:
-                logger.error("Subscription to %s failed due to:", subscription.feed_url, exc_info=e)
-                await self.send_message(
-                    chat,
-                    text=f"Subscription to {subscription.feed_url} failed due to: {e}",
-                    buttons=[[Button.inline("Delete error", "delete_me")]]
-                )
+                logger.warning("Subscription to %s failed due to:", subscription.feed_url, exc_info=e)
+                # Just increment a counter please
+                subscription.failures += 1
+                self.save_subscription(subscription)
             else:
                 for item in new_items:
                     try:

--- a/gif_pipeline/helpers/subscriptions/subscription.py
+++ b/gif_pipeline/helpers/subscriptions/subscription.py
@@ -26,7 +26,8 @@ class Subscription(ABC):
             last_check_time: Optional[datetime] = None,
             check_rate: Optional[timedelta] = None,
             enabled: bool = True,
-            seen_item_ids: Optional[List[str]] = None
+            seen_item_ids: Optional[List[str]] = None,
+            failures: int = 0,
     ):
         self.subscription_id = subscription_id
         self.chat_id = chat_id
@@ -35,6 +36,7 @@ class Subscription(ABC):
         self.last_check_time = last_check_time
         self.check_rate = check_rate or isodate.parse_duration("PT1H")
         self.enabled = enabled
+        self.failures = failures
         self.seen_item_ids = seen_item_ids or []
 
     def needs_check(self) -> bool:
@@ -62,7 +64,8 @@ class Subscription(ABC):
             self.chat_id,
             self.last_check_time.isoformat() if self.last_check_time else None,
             isodate.duration_isoformat(self.check_rate),
-            self.enabled
+            self.enabled,
+            self.failures
         )
 
     @property


### PR DESCRIPTION
Posting an error every hour for broken subscriptions is a mess, so this swaps that to instead just count the failures, and show that in subscription listing