### PR TITLE
Dynamic queue delays

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Each channel is a dictionary in the base `channels` list. They have these keys:
 - `note_time`: `boolean` (optional, default: False). If provided, and true, the send confirmation menu will note to the user when the last message was sent to the destination channel.
 - `tags`: `Tags` (optional). If provided, this will provide configuration for suggested tags for videos sent to the given channel, see below for details.
 - `twitter`: `Twitter` (optional). If provided, videos sent to this channel will also be sent to twitter. See below for details
-- `caption`: `str` (optiona), If provided, used as a jinja2 template string, which is passed a dictionary of tag names to lists of tag values, to format a caption for the destination.
+- `caption`: `str` (optional), If provided, used as a jinja2 template string, which is passed a dictionary of tag names to lists of tag values, to format a caption for the destination.
 
 #### Queue configuration
 Configuration for a channel queue. Must be a group chat, rather than another channel.
@@ -46,6 +46,8 @@ Provided to a queue, this will cause it to prompt to automatically post from the
 - `min_time`: `str`, an [iso8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) string, the minimum time between automatically prompted posts in the channel.
 - `max_time`: `str` (optional), an iso8601 duration string which, if provided, will serve as the maximum time between posts in the channel, and the automatic prompt will pick a random time between the minimum time and maximum time.
 - `order`: `str` (optional, default: "random"). Can be one of: `random`, `oldest_first`, `newest_first`, and will decide whether the automatic posting helper will suggest posting the oldest video in the queue first, the newest video, or will select a video at random.
+- `target_queue_length`: `str` (optional), an iso8601 duration string which, if provided, changes the behaviour of max and min time, and instead of being a random time between those bounds, will cause the delay to be such the number of posts in the queue should aim to last as long as the target length.
+- `schedule_variability_percent`: `int` (optional, default: 15), If provided along with a target queue length, this will be how much randomness to add to the calculated delay required to make the queue reach the target length.
 
 #### Tags configuration
 The tag configuration is the suggested tags for videos being posted to a given channel. The keys of the dictionary should be the names of the tags, and then the values should be a dictionary with the following keys, or an empty dictionary to default to defaults:

--- a/gif_pipeline/chat.py
+++ b/gif_pipeline/chat.py
@@ -218,7 +218,7 @@ class Channel(Chat):
     def est_queue_length(self) -> Optional[int]:
         if self.config.queue is None or self.config.queue.schedule is None:
             return None
-        avg_time = schedule_config.avg_time.
+        avg_time = schedule_config.avg_time
         schedule_config = self.config.queue.schedule
         if self.config.queue.schedule.target_length and self.queue.count_videos():
             avg_time = schedule_config.target_length / self.queue.count_videos()

--- a/gif_pipeline/chat.py
+++ b/gif_pipeline/chat.py
@@ -47,6 +47,11 @@ queue_duration = Gauge(
     "Estimated duration of queue, based on schedule and videos in queue",
     labelnames=["chat_title"]
 )
+queue_target = Gauge(
+    "gif_pipeline_queue_target_duration_seconds",
+    "The target duration of the given queue, if specified in config",
+    labelnames=["chat_title"]
+)
 queue_length = Gauge(
     "gif_pipeline_queue_video_count",
     "Number of videos remaining in a queue",
@@ -178,6 +183,7 @@ class Channel(Chat):
         # Set up queue duration metrics
         self.queue_duration = None
         self.queue_length = None
+        self.queue_target = None
         if self.config.queue is not None and self.config.queue.schedule is not None:
             self.queue_duration = queue_duration.labels(
                 chat_title=self.chat_data.title,
@@ -185,6 +191,10 @@ class Channel(Chat):
             self.queue_length = queue_length.labels(
                 chat_title=self.chat_data.title,
             ).set_function(lambda: self.queue.count_videos())
+            if self.config.queue.schedule.target_length:
+                self.queue_target = queue_target.labels(
+                    chat_title=self.chat_data.title,
+                ).set(self.config.queue.schedule.target_length.total_seconds())
         # Set up latest post metrics
         self.latest_post = channel_latest_post.labels(
             chat_title=self.chat_data.title,

--- a/gif_pipeline/chat.py
+++ b/gif_pipeline/chat.py
@@ -137,7 +137,7 @@ class Chat(ABC):
         return [msg for msg in self.messages if msg.has_video]
 
     def count_videos(self) -> int:
-        return len(self.video_messages)
+        return len(self.video_messages())
 
     def sum_file_size(self) -> int:
         return sum([msg.message_data.file_size for msg in self.messages if msg.message_data.has_file])
@@ -215,7 +215,7 @@ class Channel(Chat):
         logger.info(f"Subscribers: {sub_count}")
         self.sub_count.set(sub_count)
 
-    def est_queue_length(self) -> Optional[int]:
+    def est_queue_length(self) -> Optional[float]:
         if self.config.queue is None or self.config.queue.schedule is None:
             return None
         schedule_config = self.config.queue.schedule

--- a/gif_pipeline/chat.py
+++ b/gif_pipeline/chat.py
@@ -218,15 +218,16 @@ class Channel(Chat):
     def est_queue_length(self) -> Optional[int]:
         if self.config.queue is None or self.config.queue.schedule is None:
             return None
-        avg_time = schedule_config.avg_time
         schedule_config = self.config.queue.schedule
+        avg_time = schedule_config.avg_time
         if self.config.queue.schedule.target_length and self.queue.count_videos():
             avg_time = schedule_config.target_length / self.queue.count_videos()
+            variability = schedule_config.schedule_variability_percent
             if schedule_config.max_time:
-                variable_max = max_time / ((100 - schedule_config.schedule_variability_percent) / 100)
+                variable_max = schedule_config.max_time / ((100 - variability) / 100)
                 if avg_time > variable_max:
                     avg_time = variable_max
-            variable_min = min_time / ((100 + schedule_config.schedule_variability_percent) / 100)
+            variable_min = schedule_config.min_time / ((100 + variability) / 100)
             if avg_time < variable_min:
                 avg_time = variable_min
         return avg_time.total_seconds() * self.queue.count_videos()

--- a/gif_pipeline/chat.py
+++ b/gif_pipeline/chat.py
@@ -127,9 +127,12 @@ class Chat(ABC):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.chat_data.title})"
+    
+    def video_messages(self) -> List[Message]:
+        return [msg for msg in self.messages if msg.has_video]
 
     def count_videos(self) -> int:
-        return len([True for msg in self.messages if msg.has_video])
+        return len(self.video_messages)
 
     def sum_file_size(self) -> int:
         return sum([msg.message_data.file_size for msg in self.messages if msg.message_data.has_file])

--- a/gif_pipeline/chat_config.py
+++ b/gif_pipeline/chat_config.py
@@ -45,22 +45,28 @@ class ScheduleConfig:
             *,
             max_time: timedelta = None,
             order: ScheduleOrder = None,
+            target_length: timedelta = None,
+            schedule_variability_percent: int = 15,
     ):
         self.min_time = min_time
         self.max_time = max_time
         self.order = order or ScheduleOrder.RANDOM
+        self.target_length = target_length
+        self.schedule_variability_percent = schedule_variability_percent
 
     @property
     def avg_time(self) -> timedelta:
         if self.max_time is None:
             return self.min_time
-        return (self.max_time + self.min_time) / 2
+        return (self.max_time + self.min_time) / 2 # TODO
 
     @staticmethod
     def from_json(json_dict: Dict[str, Any]) -> 'ScheduleConfig':
         min_time_str = json_dict["min_time"]
         max_time_str = json_dict.get("max_time")
         order_str = json_dict.get("order")
+        target_length_str = json_dict.get("target_queue_length")
+        schedule_variability = json_dict.get("schedule_variability_percent", 15)
         min_time = isodate.parse_duration(min_time_str)
         max_time = None
         if max_time_str:
@@ -71,10 +77,15 @@ class ScheduleConfig:
                 order = ScheduleOrder[order_str.upper()]
             except KeyError as e:
                 raise KeyError(f"Invalid schedule order, \"{order_str}\": {e}")
+        target_length = None
+        if target_length_str:
+            target_length = isodate.parse_duration(target_length_str)
         return ScheduleConfig(
             min_time=min_time,
             max_time=max_time,
-            order=order
+            order=order,
+            target_length=target_length,
+            schedule_variability_percent=schedule_variability,
         )
 
 

--- a/gif_pipeline/chat_config.py
+++ b/gif_pipeline/chat_config.py
@@ -58,7 +58,7 @@ class ScheduleConfig:
     def avg_time(self) -> timedelta:
         if self.max_time is None:
             return self.min_time
-        return (self.max_time + self.min_time) / 2 # TODO
+        return (self.max_time + self.min_time) / 2
 
     @staticmethod
     def from_json(json_dict: Dict[str, Any]) -> 'ScheduleConfig':

--- a/gif_pipeline/helpers/schedule_helper.py
+++ b/gif_pipeline/helpers/schedule_helper.py
@@ -93,7 +93,7 @@ def next_post_time_for_channel(channel: 'Channel') -> datetime:
 
 def next_video_for_channel(channel: 'Channel') -> Optional['Message']:
     messages = []
-    queue_messages = channel.queue.video_messages
+    queue_messages = channel.queue.video_messages()
     if channel.schedule_config.order == ScheduleOrder.OLDEST_FIRST:
         messages = sorted(queue_messages, key=lambda msg: msg.message_data.datetime, reverse=False)
     if channel.schedule_config.order == ScheduleOrder.NEWEST_FIRST:

--- a/gif_pipeline/helpers/schedule_helper.py
+++ b/gif_pipeline/helpers/schedule_helper.py
@@ -60,7 +60,7 @@ class DelayRange:
 
 
 def next_delay_for_channel_with_target(channel: 'Channel') -> timedelta:
-    queue_length = channel.queue.count_videos
+    queue_length = channel.queue.count_videos()
     if queue_length == 0:
         return channel.schedule_config.min_time
     required_delay = channel.schedule_config.target_length / queue_length

--- a/gif_pipeline/helpers/schedule_helper.py
+++ b/gif_pipeline/helpers/schedule_helper.py
@@ -24,24 +24,76 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class DelayRange:
+    min_delay: timedelta
+    max_delay: Optional[timedelta]
+
+    @classmethod
+    def from_midpoint(cls, midpoint: timedelta, variability_parcent: int) -> "DelayRange":
+        min_delay = midpoint * ((100 - variability_parcent) / 100)
+        max_delay = midpoint * ((100 + variability_parcent) / 100)
+        return cls(min_delay, max_delay)
+    
+    def cap_min(self, min_delay: timedelta, variability_parcent: int) -> "DelayRange":
+        if self.min_delay > min_delay:
+            return self
+        return DelayRange(
+            min_delay,
+            min_delay * ((100 + variability_parcent) / (100 - variability_parcent)),
+        )
+    
+    def cap_max(self, max_delay: timedelta, variability_parcent: int) -> "DelayRange":
+        if self.max_delay < max_delay:
+            return self
+        return DelayRange(
+            max_delay * ((100 - variability_parcent) / (100 + variability_parcent)),
+            max_delay,
+        )
+    
+    def next_delay(self) -> timedelta:
+        if not self.max_delay:
+            return self.min_delay
+        min_seconds = self.min_delay.total_seconds()
+        max_seconds = self.max_delay.total_seconds()
+        return timedelta(seconds=random.uniform(min_seconds, max_seconds))
+
+
+def next_delay_for_channel_with_target(channel: 'Channel') -> timedelta:
+    queue_length = channel.queue.count_videos
+    if queue_length == 0:
+        return channel.schedule_config.min_time
+    required_delay = channel.schedule_config.target_length / queue_length
+    variability = channel.schedule_config.schedule_variability_percent
+    delay_range = DelayRange.from_midpoint(required_delay, variability)
+    delay_range = delay_range.cap_max(channel.schedule_config.max_time, variability)
+    delay_range = delay_range.cap_min(channel.schedule_config.min_time, variability)
+    return delay_range.next_delay()
+
+
+def next_delay_for_channel(channel: 'Channel') -> timedelta:
+    if channel.schedule_config.target_length:
+        return next_delay_for_channel_with_target(channel)
+    delay_range = DelayRange(
+        channel.schedule_config.min_time,
+        channel.schedule_config.max_time,
+    )
+    return delay_range.next_delay()
+
+
 def next_post_time_for_channel(channel: 'Channel') -> datetime:
-    time_delay = channel.schedule_config.min_time
-    if channel.schedule_config.max_time:
-        min_seconds = channel.schedule_config.min_time.total_seconds()
-        max_seconds = channel.schedule_config.max_time.total_seconds()
-        time_delay = timedelta(seconds=random.uniform(min_seconds, max_seconds))
+    time_delay = next_delay_for_channel(channel)
     last_post = channel.latest_message().message_data.datetime
     next_post_time = last_post + time_delay
     now = datetime.now(timezone.utc)
     if next_post_time < now:
-        # TODO: Maybe always use this?
         next_post_time = now + time_delay
     return next_post_time
 
 
 def next_video_for_channel(channel: 'Channel') -> Optional['Message']:
     messages = []
-    queue_messages = channel.queue.messages
+    queue_messages = channel.queue.video_messages
     if channel.schedule_config.order == ScheduleOrder.OLDEST_FIRST:
         messages = sorted(queue_messages, key=lambda msg: msg.message_data.datetime, reverse=False)
     if channel.schedule_config.order == ScheduleOrder.NEWEST_FIRST:


### PR DESCRIPTION
Adding a target queue length, so that channel queues can adjust their delay period to try and make the queue fit to the given target length, while obeying minimum and maximum delays, and throwing some randomness in too