### PR TITLE
Most helpers should only listen to Workshops, not channels.

### DIFF
--- a/gif_pipeline/helpers/duplicate_helper.py
+++ b/gif_pipeline/helpers/duplicate_helper.py
@@ -207,3 +207,6 @@ class DuplicateHelper(Helper):
 
     async def on_deleted_message(self, chat: Chat, message: Message):
         self.database.remove_message_hashes(message.message_data)
+
+    def can_handle(self, chat: Chat, message: Message) -> bool:
+        return True

--- a/gif_pipeline/helpers/helpers.py
+++ b/gif_pipeline/helpers/helpers.py
@@ -13,7 +13,7 @@ from telethon import Button
 from telethon.tl.types import DocumentAttributeAudio, DocumentAttributeVideo
 
 from gif_pipeline.database import Database
-from gif_pipeline.chat import Chat
+from gif_pipeline.chat import Chat, WorkshopGroup
 from gif_pipeline.menu_cache import SentMenu
 from gif_pipeline.message import Message
 from gif_pipeline.tasks.ffmpeg_task import FfmpegTask
@@ -281,6 +281,9 @@ class Helper(ABC):
 
     def is_priority(self, chat: Chat, message: Message) -> bool:
         return False
+
+    def can_handle(self, chat: Chat, message: Message) -> bool:
+        return isinstance(chat, WorkshopGroup)
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
Adding a method `can_handle()` to Helpers, which says whether they can handle a message. Maybe could use for command filtering in future, but for now this will do